### PR TITLE
Release signup and waitlist Functionality , WaitlistTeam RSpec

### DIFF
--- a/app/models/signed_up_team.rb
+++ b/app/models/signed_up_team.rb
@@ -69,6 +69,26 @@ class SignedUpTeam < ApplicationRecord
     end
   end
 
+  # def self.release_topics_selected_by_team_for_assignment(team_id, assignment_id)
+  #   old_teams_signups = SignedUpTeam.where(team_id: team_id)
+
+  #   # If the team has signed up for the topic and they are on the waitlist then remove that team from the waitlist.
+  #   unless old_teams_signups.nil?
+  #     old_teams_signups.each do |old_teams_signup|
+  #       if old_teams_signup.is_waitlisted == false # i.e., if the old team was occupying a slot, & thus is releasing a slot ...
+  #         first_waitlisted_signup = SignedUpTeam.find_by(topic_id: old_teams_signup.topic_id, is_waitlisted: true)
+  #         Invitation.remove_waitlists_for_team(old_teams_signup.topic_id, assignment_id) unless first_waitlisted_signup.nil?
+  #       end
+  #       old_teams_signup.destroy
+  #     end
+  #   end
+  # end
+
+  def self.release_topics_selected_by_team_for_assignment(team_id, assignment_id)
+    delete_all_signed_up_topics_for_team(team_id)
+    WaitlistTeam.delete_all_waitlists_for_team(team_id, assignment_id)
+  end
+
   def self.topic_id(assignment_id, user_id)
     # team_id variable represents the team_id for this user in this assignment
     team_id = TeamsUser.team_id(assignment_id, user_id)
@@ -88,6 +108,7 @@ class SignedUpTeam < ApplicationRecord
     signed_up_team = SignedUpTeam.find_by(team_id: team_id, topic_id: topic_id)
     if !signed_up_team.nil?
       ApplicationRecord.transaction do
+
         signed_up_team.destroy
         
         signed_up_teams_for_topic = SignedUpTeam.where(topic_id: topic_id)

--- a/app/models/waitlist_team.rb
+++ b/app/models/waitlist_team.rb
@@ -21,7 +21,7 @@ class WaitlistTeam < ApplicationRecord
     return true
   end
 
-  def self.remove_team_from_topic_waitlist(team_id, topic_id, user_id)
+  def self.remove_team_from_topic_waitlist(team_id, topic_id,user_id)
     waitlisted_team_for_topic = WaitlistTeam.find_by(topic_id: topic_id, team_id: team_id)
     unless waitlisted_team_for_topic.nil?
       waitlisted_team_for_topic.destroy
@@ -91,7 +91,9 @@ class WaitlistTeam < ApplicationRecord
     end
     return false
   end
+
   def self.signup_first_waitlist_team(topic_id)
+    sign_up_waitlist_team = nil
     ApplicationRecord.transaction do
       first_waitlist_team = first_team_in_waitlist_for_topic(topic_id)
       unless first_waitlist_team.blank?
@@ -107,5 +109,6 @@ class WaitlistTeam < ApplicationRecord
         end
       end
     end
+    sign_up_waitlist_team
   end
 end

--- a/app/models/waitlist_team.rb
+++ b/app/models/waitlist_team.rb
@@ -60,7 +60,7 @@ class WaitlistTeam < ApplicationRecord
     waitlisted_teams_for_topic = get_all_waitlists_for_topic topic_id
     unless waitlisted_teams_for_topic.nil?
       waitlisted_teams_for_topic.each do |entry|
-        entry.delete
+        entry.destroy
       end
     else
       ExpertizaLogger.info LoggerMessage.new('WaitlistTeam', user_id, "Cannot find Topic #{topic_id} in waitlist.")
@@ -103,5 +103,4 @@ class WaitlistTeam < ApplicationRecord
       end
     end
   end
-
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -303,6 +303,10 @@ FactoryBot.define do
     preference_priority_number nil
   end
 
+  factory :waitlist_team, class: WaitlistTeam do
+    topic { SignUpTopic.first || association(:topic) }
+  end
+
   factory :participant, class: AssignmentParticipant do
     can_submit true
     can_review true

--- a/spec/models/waitlist_team_spec.rb
+++ b/spec/models/waitlist_team_spec.rb
@@ -1,0 +1,86 @@
+describe WaitlistTeam do
+    let(:assignment) { build(:assignment, id: 1, name: 'no assgt') }
+    let(:participant) { build(:participant, user_id: 1) }
+    # let(:participant2) { build(:participant, user_id: 2) }
+    # let(:participant3) { build(:participant, user_id: 3) }
+    let(:user) { build(:student, id: 1, name: 'no name', fullname: 'no one', participants: [participant]) }
+    # let(:user2) { build(:student, id: 2, name: 'no name2', fullname: 'no one2', participants: [participant2]) }
+    let(:team) { build(:assignment_team, id: 1, name: 'no team1', users: [user]) }
+    # let(:team2) { build(:assignment_team, id: 2, name: 'no team2', users: [user2]) }
+    let(:team_user) { build(:team_user, id: 1, user: user) }
+    # let(:team_user2) { build(:team_user, id: 2, user: user2) }
+    before(:each) do
+        allow(TeamsUser).to receive(:where).with(team_id: 1).and_return([team_user])
+        # allow(TeamsUser).to receive(:where).with(team_id: 2).and_return([team_user2])
+    end
+
+    let(:topic1) { build(:topic, id: 1) }
+    let(:topic2) { build(:topic, id: 2) }
+    let(:waitlist_team1) { build(:waitlist_team) }
+    let(:waitlist_team2) { build(:waitlist_team) }
+    let(:waitlist_team3) { build(:waitlist_team) }
+    let(:signedupteam1) { build(:signed_up_team) }
+    # before(:each) do
+    #     allow(waitlist_team1).to receive(:topic_id).and_return(1)
+    #     allow(waitlist_team1).to receive(:team_id).and_return(1)
+    #     allow(waitlist_team2).to receive(:topic_id).and_return(2)
+    #     allow(waitlist_team2).to receive(:team_id).and_return(2)
+    #     allow(waitlist_team3).to receive(:topic_id).and_return(1)
+    #     allow(waitlist_team3).to receive(:team_id).and_return(3)
+    #     allow(signedupteam1).to receive(:topic_id).and_return(3)
+    # end
+
+
+    describe 'CRUD WaitlistTeam' do
+        before(:each) do
+            allow(waitlist_team1).to receive(:topic_id).and_return(1)
+            allow(waitlist_team1).to receive(:team_id).and_return(1)
+            allow(waitlist_team2).to receive(:topic_id).and_return(1)
+            allow(waitlist_team2).to receive(:team_id).and_return(2)
+        end
+
+        it 'adds and removes a team from the topic waitlist' do
+            expect(WaitlistTeam.add_team_to_topic_waitlist(waitlist_team1.team_id, waitlist_team1.topic_id,1)).to be_truthy
+            expect(WaitlistTeam.remove_team_from_topic_waitlist(waitlist_team1.team_id, waitlist_team1.topic_id,1)).to be_truthy
+        end
+
+        it 'cannot remove a team that does not exist from the topic waitlist' do
+            WaitlistTeam.add_team_to_topic_waitlist(waitlist_team1.team_id, waitlist_team1.topic_id,1)
+            expect(WaitlistTeam.remove_team_from_topic_waitlist(waitlist_team1.team_id, waitlist_team1.topic_id,1)).to be_truthy
+            expect(WaitlistTeam.remove_team_from_topic_waitlist(waitlist_team1.team_id, waitlist_team2.topic_id,1)).to be_truthy
+        end
+
+        it 'adds first waitlist team in the topic waitlist' do    
+            WaitlistTeam.add_team_to_topic_waitlist(waitlist_team1.team_id, waitlist_team1.topic_id,1)        
+            signed_up_team = WaitlistTeam.signup_first_waitlist_team(1)
+            expect(signed_up_team).to be_instance_of(SignedUpTeam) or  expect(signed_up_team).to be_nil
+            expect(WaitlistTeam.team_has_any_waitlists?(waitlist_team1.team_id)).to be_truthy
+        end
+    end
+
+    # describe '#cancel_all_waitlists' do
+    #     it 'destroys signed up teams' do
+    #       allow(SignUpTopic).to receive(:find_waitlisted_topics).and_return([topic1, topic2])
+    #       allow(SignedUpTeam).to receive(:find_by).with(topic_id: 1).and_return(signedupteam1)
+    #       allow(SignedUpTeam).to receive(:find_by).with(topic_id: 2).and_return(signedupteam2)
+    #       allow_any_instance_of(SignedUpTeam).to receive(:destroy).and_return(true)
+    #       expect(Waitlist.cancel_all_waitlists(0, 0)).to be_truthy
+    # end
+
+    # end
+    # describe '#remove_from_waitlists' do
+    #     it 'reassigns other teams' do
+    #       allow(SignedUpTeam).to receive(:where).with(team_id: 1).and_return([signedupteam1])
+    #       allow(SignedUpTeam).to receive(:where).with(topic_id: 1, is_waitlisted: false).and_return([])
+    #       allow(SignedUpTeam).to receive(:find_by).with(topic_id: 1, is_waitlisted: true).and_return(signedupteam4)
+    #       allow(SignUpTopic).to receive(:find).and_return(topic1)
+    #       allow_any_instance_of(SignedUpTeam).to receive(:destroy).and_return(true)
+    #       allow(SignUpTopic).to receive(:assign_to_first_waiting_team).and_return(true)
+    #       expect(SignUpTopic).to receive(:assign_to_first_waiting_team)
+    #       Waitlist.remove_from_waitlists(1)
+    #     end
+    # end
+    
+   
+  end
+  


### PR DESCRIPTION
This PR contains following changes:
1. When a user joins another new team and if old team becomes empty, then release all the signups and waitlists for that team